### PR TITLE
p.PubrelProperties.Unpack(b) EOF

### DIFF
--- a/pkg/mqtt/codec/v5/pubrel.go
+++ b/pkg/mqtt/codec/v5/pubrel.go
@@ -66,6 +66,8 @@ func (p *PubrelPacket) Unpack(b io.Reader) (err error) {
 		if err != nil {
 			return err
 		}
+	}
+	if p.RemainingLength > 3 {
 		err = p.PubrelProperties.Unpack(b)
 		if err != nil {
 			return err


### PR DESCRIPTION
When `RemainingLength=3`, calling `p.PubrelProperties.Unpack(b)` results in an EOF error.